### PR TITLE
Use JavaScript Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  javascript: whoop/javascript@dev:alpha
+  javascript: whoop/javascript@2
 
 jobs:
   build:
@@ -13,11 +13,9 @@ jobs:
     steps:
       - checkout
 
-#      - run:
-#          name: Log into nexus npm registry
-#          command: ./npm-login.sh
-      - javascript/npm-nexus-auth:
-          nexus_repository_name: "npm-group"
+      - run:
+          name: Log into nexus npm registry
+          command: ./npm-login.sh
 
       - run:
           name: Build
@@ -27,12 +25,6 @@ jobs:
 
       - javascript/bump-package-version:
           base_package_version: "2.20"
-
-      - run:
-          name: npm config ls -l
-          command: |
-            npm --version
-            npm config ls -l
 
       - javascript/publish-to-nexus:
           nexus_repository_name: "npm-private"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,16 @@ jobs:
       - javascript/bump-package-version:
           base_package_version: "2.20"
 
+      - run:
+          name: cat
+          command: |
+            cat package.json
+
+      - run:
+          name: npm config ls -l
+          command: |
+            npm config ls -l
+
       - javascript/publish-to-nexus:
           nexus_repository_name: "npm-private"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
 #          command: ./npm-login.sh
       - javascript/npm-nexus-auth:
           nexus_repository_name: "npm-group"
+
       - run:
           name: Build
           command: |
@@ -30,6 +31,7 @@ jobs:
       - run:
           name: npm config ls -l
           command: |
+            npm --version
             npm config ls -l
 
       - javascript/publish-to-nexus:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,19 @@ jobs:
             yarn
             yarn run build
 
+      - javascript/bump-package-version:
+          base_package_version: "2.20"
+
       - javascript/publish-to-nexus:
           nexus_repository_name: "npm-private"
+
+      - javascript/change-publish-registry-to-codeartifact:
+          code_artifact_repository_name: "whoop-npm"
+
+      - javascript/authenticate-with-codeartifact
+
+      - javascript/npm-codeartifact-auth:
+          code_artifact_repository_name: "whoop-npm"
 
       - javascript/publish-to-codeartifact:
           code_artifact_repository_name: "whoop-npm"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  javascript: whoop/javascript@2
+  javascript: whoop/javascript@dev:alpha
 
 jobs:
   build:
@@ -13,17 +13,15 @@ jobs:
     steps:
       - checkout
 
-      - javascript/npm-nexus-auth:
-          nexus_repository_name: "npm-group"
+      - run:
+          name: Log into nexus npm registry
+          command: ./npm-login.sh
 
       - run:
           name: Build
           command: |
             yarn
             yarn run build
-
-      - javascript/npm-nexus-auth:
-          nexus_repository_name: "npm-private"
 
       - javascript/bump-package-version:
           base_package_version: "2.20"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Log into nexus npm registry
-          command: ./npm-login.sh
-
+#      - run:
+#          name: Log into nexus npm registry
+#          command: ./npm-login.sh
+      - javascript/npm-nexus-auth:
+          nexus_repository_name: "npm-group"
       - run:
           name: Build
           command: |
@@ -25,11 +26,6 @@ jobs:
 
       - javascript/bump-package-version:
           base_package_version: "2.20"
-
-      - run:
-          name: cat
-          command: |
-            cat package.json
 
       - run:
           name: npm config ls -l

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  javascript: whoop/javascript@dev:alpha
+  javascript: whoop/javascript@2
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
       - javascript/bump-package-version:
           base_package_version: "2.20"
 
+      - javascript/npm-nexus-auth:
+          nexus_repository_name: "npm-private"
+
       - javascript/publish-to-nexus:
           nexus_repository_name: "npm-private"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
             yarn
             yarn run build
 
+      - javascript/npm-nexus-auth:
+          nexus_repository_name: "npm-private"
+
       - javascript/bump-package-version:
           base_package_version: "2.20"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,6 @@ jobs:
       - javascript/bump-package-version:
           base_package_version: "2.20"
 
-      - javascript/npm-nexus-auth:
-          nexus_repository_name: "npm-private"
-
       - javascript/publish-to-nexus:
           nexus_repository_name: "npm-private"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,20 @@
 version: 2.1
 
+orbs:
+  javascript: whoop/javascript@dev:alpha
+
 jobs:
   build:
-    docker:
-      - image: circleci/node:14.10.1
-
-    working_directory: ~/js-buy-sdk
+    executor:
+      name: javascript/docker
+      executor_docker_image: cimg/node:14.10.1
+      working_directory: ~/js-buy-sdk
 
     steps:
       - checkout
 
-      - run:
-          name: Log into nexus npm registry
-          command: ./npm-login.sh
+      - javascript/npm-nexus-auth:
+          nexus_repository_name: "npm-group"
 
       - run:
           name: Build
@@ -20,10 +22,11 @@ jobs:
             yarn
             yarn run build
 
-      - run:
-          name: Publish to nexus
-          command: |
-            npm publish
+      - javascript/publish-to-nexus:
+          nexus_repository_name: "npm-private"
+
+      - javascript/publish-to-codeartifact:
+          code_artifact_repository_name: "whoop-npm"
 
 workflows:
   build_and_test:


### PR DESCRIPTION
**Definition of Done:** This PR updates the circleci workflow to leverage the jobs and commands defined in the [javascript orb](https://github.com/WhoopInc/circleci-javascript-npm-orb) which is shared across all web repos. Also have current repo publish artifacts to both Nexus and CodeArtifact repositories as we are moving away from Nexus.

---
**In this PR:**
 - Use shared commands/jobs provided by the javascript orb in the circleci workflow
 - In the workflow, publish artifacts to both Nexus and CodeArtifact

---
**How to test:**
 - Example successful build:  https://app.circleci.com/pipelines/github/WhoopInc/js-buy-sdk/37/workflows/f6f666b4-7eb8-43f7-a1c9-6fc48b688b94/jobs/39

