### PR TITLE
Pull dependencies from CodeArtifact in the circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Log into nexus npm registry
-          command: ./npm-login.sh
+      - javascript/pull-auth
 
       - run:
           name: Build
@@ -26,19 +24,7 @@ jobs:
       - javascript/bump-package-version:
           base_package_version: "2.20"
 
-      - javascript/publish-to-nexus:
-          nexus_repository_name: "npm-private"
-
-      - javascript/change-publish-registry-to-codeartifact:
-          code_artifact_repository_name: "whoop-npm"
-
-      - javascript/authenticate-with-codeartifact
-
-      - javascript/npm-codeartifact-auth:
-          code_artifact_repository_name: "whoop-npm"
-
-      - javascript/publish-to-codeartifact:
-          code_artifact_repository_name: "whoop-npm"
+      - javascript/publish
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
       - javascript/bump-package-version:
           base_package_version: "2.20"
 
-      - javascript/publish
+      - javascript/publish:
+          use_legacy_nexus_auth: true
 
 workflows:
   build_and_test:


### PR DESCRIPTION
As part of the work to migrate away from Nexus to CodeArtifact, we've backfilled CodeArtifact to have all existing packages in Nexus and have been publishing all new packages to CodeArtifact. We should pull dependencies from CodeArtifact instead of Nexus now so that we can eventually tear down Nexus.

The [javascript/pull-auth](https://github.com/WhoopInc/circleci-javascript-npm-orb/blob/main/src/commands/pull-auth.yml) command defined in the web orb controls the remote repository to pull dependencies from (currently set to pulling from CodeArtifact). The [javascript/publish](https://github.com/WhoopInc/circleci-javascript-npm-orb/blob/main/src/commands/publish.yml) command covers all steps needed to publish to remote repository.